### PR TITLE
When a cell was set to empty, the cells after it were also displayed as empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func (style lineStyle) drawLine(
 		nextI := i + 1
 
 		cw := style.cellWidth(i)
-		for len(field) > 0 && text == "" && nextI != cursorPos {
+		for len(field) > 0 && field[0].Text() == "" && nextI != cursorPos {
 			cw += style.cellWidth(nextI)
 			field = field[1:]
 			nextI++


### PR DESCRIPTION
**(English)**

- Fix: When a cell was set to empty, the cells after it were also displayed as empty
(introduced in dab4348a069f745d4a2f05f033d0986684c9242d, #19).

**(Japanese)**

- あるセルを空にした時、その後のセルも空として表示されてしまう不具合を修正（dab4348a069f745d4a2f05f033d0986684c9242d #19 にて混入）