### PR TITLE
Refactor methods

### DIFF
--- a/copyandpaste.go
+++ b/copyandpaste.go
@@ -18,7 +18,7 @@ type pasteFunc func(head, dst **RowPtr, col *int, pt pasteType) error
 
 func noPaste(head, dst **RowPtr, col *int, pt pasteType) error { return nil }
 
-func (app *_Application) yankCurrentCell(src *RowPtr, col int) pasteFunc {
+func (app *application) yankCurrentCell(src *RowPtr, col int) pasteFunc {
 	dup := src.Cell[col].Clone()
 	paste := func(head, dst **RowPtr, dcol *int, pt pasteType) error {
 		if pt == pasteOver {
@@ -40,7 +40,7 @@ func (app *_Application) yankCurrentCell(src *RowPtr, col int) pasteFunc {
 	return paste
 }
 
-func (app *_Application) removeCurrentCell(src *RowPtr, col int) pasteFunc {
+func (app *application) removeCurrentCell(src *RowPtr, col int) pasteFunc {
 	paste := app.yankCurrentCell(src, col)
 	if len(src.Cell) <= 1 {
 		src.Replace(0, "", app.Config.Mode)
@@ -50,7 +50,7 @@ func (app *_Application) removeCurrentCell(src *RowPtr, col int) pasteFunc {
 	return paste
 }
 
-func (app *_Application) makeRowPaster(dup *uncsv.Row) pasteFunc {
+func (app *application) makeRowPaster(dup *uncsv.Row) pasteFunc {
 	paste := func(head, dst **RowPtr, _ *int, pt pasteType) error {
 		if m := app.checkWriteProtect(*dst); m != "" {
 			return errors.New(m)
@@ -81,7 +81,7 @@ func (app *_Application) makeRowPaster(dup *uncsv.Row) pasteFunc {
 	return paste
 }
 
-func (app *_Application) yankCurrentRow(src *RowPtr) pasteFunc {
+func (app *application) yankCurrentRow(src *RowPtr) pasteFunc {
 	dup := &uncsv.Row{Term: src.Term}
 	for _, c := range src.Cell {
 		dup.Cell = append(dup.Cell, c.Clone())
@@ -89,7 +89,7 @@ func (app *_Application) yankCurrentRow(src *RowPtr) pasteFunc {
 	return app.makeRowPaster(dup)
 }
 
-func (app *_Application) removeCurrentRow(head, src **RowPtr) pasteFunc {
+func (app *application) removeCurrentRow(head, src **RowPtr) pasteFunc {
 	if app.Len() <= 1 {
 		return noPaste
 	}
@@ -117,7 +117,7 @@ func (app *_Application) removeCurrentRow(head, src **RowPtr) pasteFunc {
 	return paste
 }
 
-func (app *_Application) yankCurrentColumn(col int) pasteFunc {
+func (app *application) yankCurrentColumn(col int) pasteFunc {
 	dup := []uncsv.Cell{}
 	for p := app.Front(); p != nil; p = p.Next() {
 		var newCell uncsv.Cell
@@ -161,7 +161,7 @@ func (app *_Application) yankCurrentColumn(col int) pasteFunc {
 	}
 }
 
-func (app *_Application) removeCurrentColumn(col int) pasteFunc {
+func (app *application) removeCurrentColumn(col int) pasteFunc {
 	paste := app.yankCurrentColumn(col)
 	for p := app.Front(); p != nil; p = p.Next() {
 		if len(p.Cell) > 1 && col < len(p.Cell) {

--- a/main.go
+++ b/main.go
@@ -306,7 +306,7 @@ func (v *viewCache) Draw(header, startRow, cursorRow *RowPtr, _cellWidth *CellWi
 	}.drawPage(enum, cursorCol-startCol, cursorRow.lnum-startRow.lnum, v.bodyCache, out)
 }
 
-func (app *_Application) MessageAndGetKey(message string) (string, error) {
+func (app *application) MessageAndGetKey(message string) (string, error) {
 	fmt.Fprintf(app, "%s\r%s%s ", ansi.YELLOW, message, ansi.ERASE_LINE)
 	io.WriteString(app, ansi.CURSOR_ON)
 	ch, err := app.GetKey()
@@ -314,7 +314,7 @@ func (app *_Application) MessageAndGetKey(message string) (string, error) {
 	return ch, err
 }
 
-func (app *_Application) YesNo(message string) bool {
+func (app *application) YesNo(message string) bool {
 	ch, err := app.MessageAndGetKey(message)
 	return err == nil && ch == "y"
 }
@@ -393,7 +393,7 @@ type CellValidatedEvent struct {
 }
 
 type KeyEventArgs struct {
-	*_Application
+	*application
 	CursorRow *RowPtr
 	CursorCol int
 }
@@ -486,7 +486,7 @@ func (cfg *Config) checkWriteProtectAndColumn(cursorRow *RowPtr) string {
 	return ""
 }
 
-func (app *_Application) readlineAndValidate(prompt, text string, row *RowPtr, col int) (string, error) {
+func (app *application) readlineAndValidate(prompt, text string, row *RowPtr, col int) (string, error) {
 	candidates := makeCandidate(row.lnum-1, col, row)
 	for {
 		var err error
@@ -502,7 +502,7 @@ func (app *_Application) readlineAndValidate(prompt, text string, row *RowPtr, c
 	}
 }
 
-func (app *_Application) tryQuit(fetch func() (bool, *uncsv.Row, error)) (*Result, error) {
+func (app *application) tryQuit(fetch func() (bool, *uncsv.Row, error)) (*Result, error) {
 	if !app.ReadOnly && app.isDirty() {
 		ch, err := app.MessageAndGetKey(`Quit: Save changes ? ["y": save, "n": quit without saving, other: cancel]`)
 		if err != nil {
@@ -519,7 +519,7 @@ func (app *_Application) tryQuit(fetch func() (bool, *uncsv.Row, error)) (*Resul
 		}
 	}
 	io.WriteString(app.out, "\n")
-	return &Result{_Application: app}, nil
+	return &Result{application: app}, nil
 
 }
 
@@ -548,7 +548,7 @@ func (cfg *Config) edit(fetch func() (*uncsv.Row, error), out io.Writer) (*Resul
 		defer pilot.Close()
 		cfg.Pilot = pilot
 	}
-	app := &_Application{
+	app := &application{
 		Config:   cfg,
 		csvLines: list.New(),
 		out:      out,
@@ -660,13 +660,13 @@ func (cfg *Config) edit(fetch func() (*uncsv.Row, error), out io.Writer) (*Resul
 
 		if handler, ok := cfg.KeyMap[ch]; ok {
 			e := &KeyEventArgs{
-				CursorRow:    cursorRow,
-				CursorCol:    cursorCol,
-				_Application: app,
+				CursorRow:   cursorRow,
+				CursorCol:   cursorCol,
+				application: app,
 			}
 			cmdResult, err := handler(e)
 			if err != nil || cmdResult.Quit {
-				return &Result{_Application: app}, err
+				return &Result{application: app}, err
 			}
 			message = cmdResult.Message
 		} else {

--- a/rowptr.go
+++ b/rowptr.go
@@ -66,7 +66,7 @@ func (r *RowPtr) Index() int {
 	return r.lnum
 }
 
-type _Application struct {
+type application struct {
 	csvLines    *list.List
 	removedRows []*uncsv.Row
 	out         io.Writer
@@ -74,29 +74,29 @@ type _Application struct {
 	*Config
 }
 
-func (app *_Application) ResetDirty() {
+func (app *application) ResetDirty() {
 	app.dirty = 0
 }
 
-func (app *_Application) isDirty() bool {
+func (app *application) isDirty() bool {
 	return app.dirty != 0
 }
 
-func (app *_Application) setHardDirty() {
+func (app *application) setHardDirty() {
 	app.dirty |= 1
 }
 
-func (app *_Application) increaseSoftDirty() {
+func (app *application) increaseSoftDirty() {
 	app.dirty += 2
 }
 
-func (app *_Application) decreaseSoftDirty() {
+func (app *application) decreaseSoftDirty() {
 	if app.dirty >= 2 {
 		app.dirty -= 2
 	}
 }
 
-func (app *_Application) updateSoftDirty(before, after bool) {
+func (app *application) updateSoftDirty(before, after bool) {
 	if before == after {
 		return
 	}
@@ -107,35 +107,35 @@ func (app *_Application) updateSoftDirty(before, after bool) {
 	}
 }
 
-func (app *_Application) resetSoftDirty() {
+func (app *application) resetSoftDirty() {
 	app.dirty &= 1
 }
 
 type Result struct {
-	*_Application
+	*application
 }
 
-func (app *_Application) Write(data []byte) (int, error) {
+func (app *application) Write(data []byte) (int, error) {
 	return app.out.Write(data)
 }
 
-func (app *_Application) Front() *RowPtr {
+func (app *application) Front() *RowPtr {
 	return frontPtr(app.csvLines)
 }
 
-func (app *_Application) Back() *RowPtr {
+func (app *application) Back() *RowPtr {
 	return backPtr(app.csvLines)
 }
 
-func (app *_Application) Len() int {
+func (app *application) Len() int {
 	return app.csvLines.Len()
 }
 
-func (app *_Application) Push(row *uncsv.Row) {
+func (app *application) Push(row *uncsv.Row) {
 	app.csvLines.PushBack(row)
 }
 
-func (app *_Application) Each(callback func(*uncsv.Row) bool) {
+func (app *application) Each(callback func(*uncsv.Row) bool) {
 	for p := app.Front(); p != nil; p = p.Next() {
 		if !callback(p.Row) {
 			break
@@ -143,7 +143,7 @@ func (app *_Application) Each(callback func(*uncsv.Row) bool) {
 	}
 }
 
-func (app *_Application) RemovedRows(callback func(*uncsv.Row) bool) {
+func (app *application) RemovedRows(callback func(*uncsv.Row) bool) {
 	for _, p := range app.removedRows {
 		if !callback(p) {
 			break

--- a/write.go
+++ b/write.go
@@ -15,7 +15,7 @@ import (
 
 var overWritten = map[string]struct{}{}
 
-func (app *_Application) dump(w io.Writer) {
+func (app *application) dump(w io.Writer) {
 	cursor := app.Front()
 	app.Config.Mode.DumpBy(
 		func() *uncsv.Row {
@@ -31,7 +31,7 @@ func (app *_Application) dump(w io.Writer) {
 
 var errCanceled = errors.New("canceled")
 
-func (app *_Application) getFname() (string, error) {
+func (app *application) getFname() (string, error) {
 	fname := "-"
 	if args := flag.Args(); len(args) >= 1 {
 		var err error
@@ -43,7 +43,7 @@ func (app *_Application) getFname() (string, error) {
 	return app.GetFilename(app, "write to>", fname)
 }
 
-func (app *_Application) cmdWrite(fname string) (string, error) {
+func (app *application) cmdWrite(fname string) (string, error) {
 	if fname == "-" {
 		app.dump(os.Stdout)
 		return "Output to STDOUT", nil
@@ -73,7 +73,7 @@ func (app *_Application) cmdWrite(fname string) (string, error) {
 	return fmt.Sprintf("Saved as \"%s\"", fname), nil
 }
 
-func (app *_Application) trySave(fetch func() (bool, *uncsv.Row, error)) (string, error) {
+func (app *application) trySave(fetch func() (bool, *uncsv.Row, error)) (string, error) {
 	var wg sync.WaitGroup
 	chStop := make(chan struct{})
 	defer close(chStop)


### PR DESCRIPTION
- Rename `_View` to `viewCache`
- Rename `_Application` to `application`
- Refactored methods of type `_Application`
  - Remove reduntant arguments which are `io.Writer`
  - Change some functions to methods