### PR TITLE
internal/nonblock: simplify data input handling by using io.EOF

### DIFF
--- a/write.go
+++ b/write.go
@@ -95,14 +95,13 @@ func (app *application) cmdSave() (string, error) {
 				case <-chStop:
 					return
 				default:
-					ok, row, err := app.fetch()
-					if !ok {
-						return
-					}
+					row, err := app.fetch()
 					if err != nil && !errors.Is(err, io.EOF) {
 						return
 					}
-					app.Push(row)
+					if row != nil {
+						app.Push(row)
+					}
 					if errors.Is(err, io.EOF) {
 						return
 					}


### PR DESCRIPTION
The boolean return value was originally added to clarify whether data input should continue, especially around io.EOF.

In practice, combining (bool, T, error) made the control flow harder to reason about. This change removes the flag and relies
on standard io.EOF checks instead.
