### PR TITLE
README: Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,13 @@ Download the binary package from [Releases](https://github.com/hymkor/csvi/relea
 
 <!-- pwsh -Command "readme-install.ps1" | -->
 
-### Use "go install" (requires Go toolchain)
+### Use [eget] installer (cross-platform)
 
-```
-go install github.com/hymkor/csvi/cmd/csvi@latest
-```
+```sh
+brew install eget        # Unix-like systems
+# or
+scoop install eget       # Windows
 
-Because `go install` introduces the executable into `$HOME/go/bin` or `$GOPATH/bin`, you need to add this directory to your $PATH to execute `csvi`.
-
-### Use [eget] installer (cross-platform)"
-
-```
 cd (YOUR-BIN-DIRECTORY)
 eget hymkor/csvi
 ```
@@ -92,6 +88,14 @@ scoop install csvi
 ```
 
 [scoop]: https://scoop.sh/
+
+### Use "go install" (requires Go toolchain)
+
+```
+go install github.com/hymkor/csvi/cmd/csvi@latest
+```
+
+Because `go install` introduces the executable into `$HOME/go/bin` or `$GOPATH/bin`, you need to add this directory to your `$PATH` to execute `csvi`.
 <!-- -->
 
 Usage

--- a/README_ja.md
+++ b/README_ja.md
@@ -59,19 +59,15 @@ Install
 > &#9888;&#65039; Note: macOS用バイナリは実験的ビルドで、検証できていません。
 > もし何らかの問題を確認されましたらお知らせください！
 
-<!-- pwsh -Command "readme-install.ps1 'ja'" -->
-
-### "go install" を使う場合 (要Go言語開発環境)
-
-```
-go install github.com/hymkor/csvi@latest
-```
-
-`go install` は `$HOME/go/bin` もしくは `$GOPATH/bin` へ実行ファイルを導入するので、`csvi` を実行するにはそのディレクトリを `$PATH` に追加する必要があります。
+<!-- pwsh -Command "readme-install.ps1 'ja'" | -->
 
 ### [eget] インストーラーを使う場合 (クロスプラットフォーム)
 
-```
+```sh
+brew install eget        # Unix-like systems
+# or
+scoop install eget       # Windows
+
 cd (YOUR-BIN-DIRECTORY)
 eget hymkor/csvi
 ```
@@ -93,6 +89,13 @@ scoop install csvi
 
 [scoop]: https://scoop.sh/
 
+### "go install" を使う場合 (要Go言語開発環境)
+
+```
+go install github.com/hymkor/csvi/cmd/csvi@latest
+```
+
+`go install` は `$HOME/go/bin` もしくは `$GOPATH/bin` へ実行ファイルを導入するので、`csvi` を実行するにはそのディレクトリを `$PATH` に追加する必要があります。
 <!-- -->
 
 Usage


### PR DESCRIPTION
### (English)
- Improve the installation section
  - Since `eget` is currently the easiest option for macOS and Linux users, its usage is now described first, starting from how to install `eget` via Homebrew or Scoop.
  - The `go install` instructions were moved to the end because they may require installing the full Go toolchain.

### (Japanese)
- インストールセクションを改善
  - macOS / Linux ユーザにとっては今のところ eget が一番手軽なため、eget の説明を先頭へ移動。homebrew/scoop で eget を入れるところから手順を提示
  - go install の説明は、Go言語一式のインストールまで要求してしまう場合があるため、最後へ移動