### PR TITLE
"internal/manualctl": Rename `PendingEscTty` to `pendingEscTty` and refine its behavior

### DIFF
--- a/internal/manualctl/main.go
+++ b/internal/manualctl/main.go
@@ -41,7 +41,7 @@ type ManualCtl struct {
 
 func New() (*ManualCtl, error) {
 	mc := &ManualCtl{
-		Tty: &PendingEscTty{Tty: &tty8.Tty{}},
+		Tty: pendingEscTty{Tty: &tty8.Tty{}},
 	}
 	return mc, mc.Open(nil)
 }

--- a/internal/manualctl/pendingesc.go
+++ b/internal/manualctl/pendingesc.go
@@ -4,23 +4,29 @@ import (
 	"github.com/nyaosorg/go-ttyadapter"
 )
 
-// PendingEscTty buffers the ESC key to avoid misinterpreting
+// pendingEscTty buffers the ESC key to avoid misinterpreting
 // partially received key sequences.
-type PendingEscTty struct {
+type pendingEscTty struct {
 	ttyadapter.Tty
-	pending string
 }
 
-func (p *PendingEscTty) GetKey() (string, error) {
-	key, err := p.Tty.GetKey()
-	join := p.pending + key
-	switch join {
-	case "\x1B", "\x1B[":
-		p.pending = join
-		key = ""
-	default:
-		p.pending = ""
-		key = join
+// GetKey returns only when a complete key sequence is received.
+// Partial escape sequences are buffered internally.
+func (p pendingEscTty) GetKey() (string, error) {
+	var sequence string
+	for {
+		key, err := p.Tty.GetKey()
+		if err != nil {
+			return "", err
+		}
+		sequence += key
+		switch sequence {
+		case "\x1B", "\x1B[", "\x1B[1", "\x1B[15", "\x1B[16", "\x1B[17",
+			"\x1B[18", "\x1B[1;", "\x1B[1;5", "\x1B[2", "\x1B[20",
+			"\x1B[21", "\x1B[23", "\x1B[24", "\x1B[3", "\x1B[5",
+			"\x1B[5;", "\x1B[5;5", "\x1B[6", "\x1B[6;", "\x1B[6;5", "\x1B[O":
+		default:
+			return sequence, nil
+		}
 	}
-	return key, err
 }


### PR DESCRIPTION
(English)
- "internal/manualctl": Rename `PendingEscTty` to `pendingEscTty` and refine its behavior
- Extended the input buffering logic, which previously handled only "\x1B" and "\x1B[", to cover all relevant escape sequence patterns.

(Japanese)
- "internal/manualctl": `PendingEscTty` を `pendingEscTty` に改名し、動作を改善した。
- これまで "\x1B" および "\x1B[" のみに対して行っていたキーシーケンスのバッファリング処理を、想定されるすべてのエスケープシーケンスに対して行うように拡張した。